### PR TITLE
fix: ensured the payee memo/note can contain pipe characters

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -1156,10 +1156,10 @@
           },
           {
             "type": "Terminal",
-            "name": "Text",
-            "label": "Text",
+            "name": "Memo",
+            "label": "Memo",
             "idx": 1,
-            "pattern": "[^|;\\r\\n]+"
+            "pattern": "[^;\\r\\n]+"
           }
         ]
       }

--- a/src/__tests__/cst_to_raw_visitor/description.test.ts
+++ b/src/__tests__/cst_to_raw_visitor/description.test.ts
@@ -41,4 +41,22 @@ test('returns a transaction object with a description and memo', (t) => {
   );
 });
 
-// TODO: Write tests wrt the following issue: https://github.com/jonestristand/hledger-parser/issues/2
+test('returns a transaction object with a description and memo containing pipe characters', (t) => {
+  const result = CstToRawVisitor.journal(
+    parseLedgerToCST(`1900/01/01 payee | memo | note | text\n`).cstJournal.children
+  );
+  t.is(
+    result.length,
+    1,
+    'should modify a transaction posting with a payee and memo containing pipe characters'
+  );
+  t.is(result[0].type, 'transaction', 'should be a transaction object');
+  t.deepEqual(
+    (result[0] as Raw.Transaction).value.description,
+    {
+      payee: 'payee',
+      memo: 'memo | note | text'
+    },
+    'should contain a transaction posting line with a payee and memo containing pipe characters'
+  );
+});

--- a/src/__tests__/lexer/transactions.test.ts
+++ b/src/__tests__/lexer/transactions.test.ts
@@ -43,7 +43,7 @@ const tests = [
       { ParenValue: 'a' },
       'Text',
       'PIPE',
-      'Text',
+      'Memo',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',
@@ -121,6 +121,11 @@ const tests = [
       'NEWLINE'
     ],
     title: 'recognize a maximal transaction'
+  },
+  {
+    pattern: '1900/01/01 New York Steakhouse|memo|note|something else|',
+    expected: ['DateAtStart', 'Text', 'PIPE', 'Memo'],
+    title: 'recognize a transaction with a payee note containing pipe characters'
   }
 ];
 

--- a/src/__tests__/parser/description.test.ts
+++ b/src/__tests__/parser/description.test.ts
@@ -1,6 +1,6 @@
 import anyTest, { TestInterface } from 'ava';
 
-import { PIPE, Text } from '../../lib/lexer/tokens';
+import { Memo, PIPE, Text } from '../../lib/lexer/tokens';
 import HLedgerParser from '../../lib/parser';
 import { MockLexer, simplifyCst } from '../utils';
 
@@ -25,21 +25,38 @@ test('parses a description', (t) => {
   );
 });
 
-test('parses a description with a single memo', (t) => {
+test('parses a description with a memo', (t) => {
   t.context.lexer
     .addToken(Text, 'payee')
     .addToken(PIPE, '|')
-    .addToken(Text, 'memo');
+    .addToken(Memo, 'memo');
   HLedgerParser.input = t.context.lexer.tokenize();
 
   t.deepEqual(
     simplifyCst(HLedgerParser.description()),
     {
-      Text: 2,
-      PIPE: 1
+      Text: 1,
+      PIPE: 1,
+      Memo: 1
     },
     '<description> payee|memo'
   );
 });
 
-// TODO: Write tests wrt the following issue: https://github.com/jonestristand/hledger-parser/issues/2
+test('parses a description with a memo containing pipe characters', (t) => {
+  t.context.lexer
+    .addToken(Text, 'payee')
+    .addToken(PIPE, '|')
+    .addToken(Memo, 'memo|note|text')
+  HLedgerParser.input = t.context.lexer.tokenize();
+
+  t.deepEqual(
+    simplifyCst(HLedgerParser.description()),
+    {
+      Text: 1,
+      PIPE: 1,
+      Memo: 1
+    },
+    '<description> payee|memo|note|text'
+  );
+});

--- a/src/lib/hledger_cst.ts
+++ b/src/lib/hledger_cst.ts
@@ -239,8 +239,9 @@ export interface DescriptionCstNode extends CstNode {
 }
 
 export type DescriptionCstChildren = {
-  Text: (IToken)[];
+  Text: IToken[];
   PIPE?: IToken[];
+  Memo?: IToken[];
 };
 
 export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {

--- a/src/lib/lexer/index.ts
+++ b/src/lib/lexer/index.ts
@@ -7,6 +7,7 @@ import {
   indent_mode,
   inline_comment_mode,
   inline_comment_tag_mode,
+  memo_mode,
   posting_amount_mode,
   posting_mode,
   price_amounts_mode,
@@ -26,6 +27,7 @@ export const tokenModeDefinitions = {
     posting_amount_mode,
     price_mode,
     price_amounts_mode,
+    memo_mode,
     default_mode
   },
   defaultMode: 'default_mode'

--- a/src/lib/lexer/modes.ts
+++ b/src/lib/lexer/modes.ts
@@ -19,6 +19,7 @@ import {
   JournalDate,
   JournalNumber,
   LPAREN,
+  Memo,
   MultipleWSPostingMode,
   NEWLINE,
   ParenValue,
@@ -137,4 +138,10 @@ export const price_amounts_mode = [
   CommodityText,
   DASH,
   PLUS
+];
+
+export const memo_mode = [
+  SemicolonComment,
+  NEWLINE,
+  Memo
 ];

--- a/src/lib/lexer/tokens.ts
+++ b/src/lib/lexer/tokens.ts
@@ -44,8 +44,6 @@ export const COLON = createToken({ name: 'COLON', pattern: ':' });
 export const EXCLAMATION = createToken({ name: 'EXCLAMATION', pattern: '!' });
 export const EQUALS = createToken({ name: 'EQUALS', pattern: '=' });
 export const AT = createToken({ name: 'AT', pattern: '@' });
-export const PIPE = createToken({ name: 'PIPE', pattern: '|' });
-
 export const SEMICOLON = createToken({ name: 'SEMICOLON', pattern: /;/ });
 export const HASHTAG = createToken({ name: 'HASHTAG', pattern: /#/ });
 export const ASTERISK = createToken({ name: 'ASTERISK', pattern: /\*/ });
@@ -226,6 +224,19 @@ export const ParenValue = createToken({
 export const Text = createToken({
   name: 'Text',
   pattern: /[^|;\r\n]+/ ///[a-zA-Z_][a-zA-Z _]*[a-zA-Z_]/
+});
+
+export const PIPE = createToken({
+  name: 'PIPE',
+  pattern: '|',
+  line_breaks: false,
+  push_mode: 'memo_mode'
+});
+
+export const Memo = createToken({
+  name: 'Memo',
+  pattern: /[^;\r\n]+/,
+  line_breaks: false
 });
 
 // ====- Price Directive Tokens -====

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -22,6 +22,7 @@ import {
   JournalDate,
   JournalNumber,
   LPAREN,
+  Memo,
   NEWLINE,
   ParenValue,
   PDirective,
@@ -304,7 +305,7 @@ class HLedgerParser extends CstParser {
     this.CONSUME(Text);
     this.OPTION(() => {
       this.CONSUME(PIPE);
-      this.CONSUME1(Text);
+      this.CONSUME1(Memo);
     });
   });
 }

--- a/src/lib/visitors/cst_to_raw.ts
+++ b/src/lib/visitors/cst_to_raw.ts
@@ -4,6 +4,7 @@ import { notEmpty } from '../type_utils';
 import type * as ParserTypes from '../hledger_cst';
 import type * as Core from '../types';
 import type * as Raw from './raw_types';
+import type { IToken } from 'chevrotain';
 
 const BaseCstVisitor = HLedgerParser.getBaseCstVisitorConstructor();
 
@@ -326,13 +327,13 @@ class HledgerToRawVisitor extends BaseCstVisitor {
   }
 
   description(ctx: ParserTypes.DescriptionCstChildren): Core.TxnDescription {
-    if (ctx.Text.length == 1) {
-      return ctx.Text[0].image.trim();
-    } else if (ctx.Text.length == 2) {
+    if (ctx.Memo) {
       return {
         payee: ctx.Text[0].image.trim(),
-        memo: ctx.Text[1].image.trim()
+        memo: (ctx.Memo as IToken[])[0].image.trim()
       };
+    } else if (ctx.Text.length == 1) {
+      return ctx.Text[0].image.trim();
     } else {
       return ''; // default blank description
     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
  - Throws an error when transaction memo text contains pipe characters in addition to the pipe that delimits the transaction description (payee)

- **What is the new behavior (if this is a feature change)?**
  - The extra pipe characters are now parsed as regular text in the memo, as per the [documentation](https://hledger.org/1.31/hledger.html#payee-and-note)

- **Other information**:
  - N/A

fixes #2