### PR TITLE
fix: enforced double space between account directive and inline comment

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -369,14 +369,21 @@
       },
       {
         "type": "Terminal",
-        "name": "RealAccountName",
-        "label": "RealAccountName",
+        "name": "AccountName",
+        "label": "AccountName",
         "idx": 0
       },
       {
         "type": "Option",
         "idx": 0,
         "definition": [
+          {
+            "type": "Terminal",
+            "name": "DOUBLE_WS",
+            "label": "DOUBLE_WS",
+            "idx": 0,
+            "pattern": "[ \\t]{2}"
+          },
           {
             "type": "NonTerminal",
             "name": "inlineComment",

--- a/src/__tests__/cst_to_raw_ledger.test.ts
+++ b/src/__tests__/cst_to_raw_ledger.test.ts
@@ -15,7 +15,7 @@ test('converts from concrete syntax tree to raw journal', (t) => {
     Assets:Investments     20 funds @ $1.00
 
 account Assets:Chequing
-account Expenses:Food ; type: E
+account Expenses:Food  ; type: E
 
 # Full-line comment
 

--- a/src/__tests__/cst_to_raw_visitor/account_directive.test.ts
+++ b/src/__tests__/cst_to_raw_visitor/account_directive.test.ts
@@ -27,7 +27,7 @@ test('returns an account directive object', (t) => {
 
 test('returns an account directive object with a comment', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test:account ; comment\n`).cstJournal.children
+    parseLedgerToCST(`account test:account  ; comment\n`).cstJournal.children
   );
   t.is(
     result.length,

--- a/src/__tests__/cst_to_raw_visitor/inline_comment.test.ts
+++ b/src/__tests__/cst_to_raw_visitor/inline_comment.test.ts
@@ -6,7 +6,7 @@ import * as Raw from '../../lib/visitors/raw_types';
 
 test('returns an inline comment object when inline comment is empty', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ;\n`).cstJournal.children
+    parseLedgerToCST(`account test  ;\n`).cstJournal.children
   );
   t.is(result.length, 1, 'should modify an empty inline comment');
   t.truthy(
@@ -22,7 +22,7 @@ test('returns an inline comment object when inline comment is empty', (t) => {
 
 test('returns an inline comment object when inline comment contains a single white-space', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ; \n`).cstJournal.children
+    parseLedgerToCST(`account test  ; \n`).cstJournal.children
   );
   t.is(result.length, 1, 'should modify an inline comment of one white-space');
   t.truthy(
@@ -38,7 +38,7 @@ test('returns an inline comment object when inline comment contains a single whi
 
 test('returns an inline comment object when inline comment contains multiple white-space', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ;  \t \n`).cstJournal.children
+    parseLedgerToCST(`account test  ;  \t \n`).cstJournal.children
   );
   t.is(
     result.length,
@@ -58,7 +58,7 @@ test('returns an inline comment object when inline comment contains multiple whi
 
 test('returns an inline comment object when inline comment contains text', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ; comment\n`).cstJournal.children
+    parseLedgerToCST(`account test  ; comment\n`).cstJournal.children
   );
   t.is(result.length, 1, 'should modify an inline comment with text');
   t.truthy(
@@ -74,7 +74,7 @@ test('returns an inline comment object when inline comment contains text', (t) =
 
 test('returns an inline comment object when inline comment contains text, tags, and tag values', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ; comment tag-name: tag-value, tag-name2:\n`)
+    parseLedgerToCST(`account test  ; comment tag-name: tag-value, tag-name2:\n`)
       .cstJournal.children
   );
   t.is(result.length, 1, 'should modify an inline comment with text and a tag');

--- a/src/__tests__/cst_to_raw_visitor/inline_comment_item.test.ts
+++ b/src/__tests__/cst_to_raw_visitor/inline_comment_item.test.ts
@@ -6,7 +6,7 @@ import * as Raw from '../../lib/visitors/raw_types';
 
 test('returns an inline comment object from inline comment text', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ; comment text item\n`).cstJournal.children
+    parseLedgerToCST(`account test  ; comment text item\n`).cstJournal.children
   );
   t.is(result.length, 1, 'should modify an inline comment with text');
   t.truthy(
@@ -22,7 +22,7 @@ test('returns an inline comment object from inline comment text', (t) => {
 
 test('returns an inline comment object from inline comment tag and value', (t) => {
   const result = CstToRawVisitor.journal(
-    parseLedgerToCST(`account test ; comment-tag-item: value\n`).cstJournal
+    parseLedgerToCST(`account test  ; comment-tag-item: value\n`).cstJournal
       .children
   );
   t.is(

--- a/src/__tests__/lexer/account_directives.test.ts
+++ b/src/__tests__/lexer/account_directives.test.ts
@@ -3,25 +3,28 @@ import { runLexerTests } from './utils';
 const tests = [
   {
     pattern: 'account Assets:Chequing  ',
-    expected: ['AccountDirective', { RealAccountName: ['Assets', 'Chequing'] }],
+    expected: [
+      'AccountDirective',
+      { AccountName: ['Assets', 'Chequing'] },
+      'DOUBLE_WS'
+    ],
     title: 'recognize account directive and name with double-space at end'
   },
   {
     pattern: 'account Assets:Chequing\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets', 'Chequing'] },
+      { AccountName: ['Assets', 'Chequing'] },
       'NEWLINE'
     ],
     title: 'recognize account directive and name with end of line at end'
   },
   {
-    // TODO: Account directive comments require two spaces between that and the account name.
-    //  Tests need to be corrected to reflect this format. See: https://hledger.org/1.31/hledger.html#account-comments
-    pattern: 'account Assets:Chequing ; a comment\n',
+    pattern: 'account Assets:Chequing  ; a comment\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets', 'Chequing'] },
+      { AccountName: ['Assets', 'Chequing'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'NEWLINE'
@@ -29,10 +32,11 @@ const tests = [
     title: 'recognize account directive and name with comment at end'
   },
   {
-    pattern: 'account Assets:Chequing ; a comment with: a tag\n',
+    pattern: 'account Assets:Chequing  ; a comment with: a tag\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets', 'Chequing'] },
+      { AccountName: ['Assets', 'Chequing'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',
@@ -46,7 +50,7 @@ const tests = [
     pattern: 'account Assets:Chequing\n    ; a comment\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets', 'Chequing'] },
+      { AccountName: ['Assets', 'Chequing'] },
       'NEWLINE',
       'INDENT',
       'SemicolonComment',
@@ -59,7 +63,8 @@ const tests = [
     pattern: 'account (Assets:Chequing)  ',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['(Assets', 'Chequing)'] }
+      { AccountName: ['(Assets', 'Chequing)'] },
+      'DOUBLE_WS'
     ],
     title:
       'ignore ( and treat it as part of the account name of a real account (hledger bug)'
@@ -68,7 +73,8 @@ const tests = [
     pattern: 'account [Assets:Chequing]  ',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['[Assets', 'Chequing]'] }
+      { AccountName: ['[Assets', 'Chequing]'] },
+      'DOUBLE_WS'
     ],
     title:
       'ignore [ and treat it as part of the account name of a real account (hledger bug)'

--- a/src/__tests__/lexer/tags.test.ts
+++ b/src/__tests__/lexer/tags.test.ts
@@ -5,7 +5,8 @@ const tests = [
     pattern: 'account Assets  ; tag:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -17,7 +18,8 @@ const tests = [
     pattern: 'account Assets  ; tag1:,tag2:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -32,7 +34,8 @@ const tests = [
     pattern: 'account Assets  ; tag: value\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -45,7 +48,8 @@ const tests = [
     pattern: 'account Assets  ; tag1: value1,tag2:value2\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -62,7 +66,8 @@ const tests = [
     pattern: 'account Assets  ; comment tag:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',
@@ -75,7 +80,8 @@ const tests = [
     pattern: 'account Assets  ; tag:, comment\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -89,7 +95,8 @@ const tests = [
     pattern: 'account Assets  ; tag: value, comment\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -104,7 +111,8 @@ const tests = [
     pattern: 'account Assets  ; tag1:, comment tag2:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -120,7 +128,8 @@ const tests = [
     pattern: 'account Assets  ; :tag:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',
@@ -133,7 +142,8 @@ const tests = [
     pattern: 'account Assets  ; :tag1:tag2:tag3:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',
@@ -147,7 +157,8 @@ const tests = [
     pattern: 'account Assets  ; ~`!@#$%^&*()_-+={},[]\\|"\'.<;>tag1:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -159,7 +170,8 @@ const tests = [
     pattern: 'account Assets  ; 标签:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -171,7 +183,8 @@ const tests = [
     pattern: 'account Assets  ; بطاقةشعار:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -183,7 +196,8 @@ const tests = [
     pattern: 'account Assets  ; תָג:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -195,7 +209,8 @@ const tests = [
     pattern: 'account Assets  ; Тег:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -207,7 +222,8 @@ const tests = [
     pattern: 'account Assets  ; ,:value\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentTagName',
       'InlineCommentTagColon',
@@ -220,7 +236,8 @@ const tests = [
     pattern: 'account Assets  ; ::::::tag1:\n',
     expected: [
       'AccountDirective',
-      { RealAccountName: ['Assets'] },
+      { AccountName: ['Assets'] },
+      'DOUBLE_WS',
       'SemicolonComment',
       'InlineCommentText',
       'InlineCommentTagName',

--- a/src/__tests__/parse_ledger_to_cooked.test.ts
+++ b/src/__tests__/parse_ledger_to_cooked.test.ts
@@ -15,7 +15,7 @@ test('correctly parses a properly formatted hledger journal', (t) => {
     Assets:Investments     20 funds @ $1.00
 
 account Assets:Chequing
-account Expenses:Food ; type: E
+account Expenses:Food  ; type: E
 
 # Full-line comment
 

--- a/src/__tests__/parse_ledger_to_cst.test.ts
+++ b/src/__tests__/parse_ledger_to_cst.test.ts
@@ -16,7 +16,7 @@ test('correctly lexes a properly formatted hledger journal', (t) => {
     Assets:Investments     20 funds @ $1.00
 
 account Assets:Chequing
-account Expenses:Food ; type: E
+account Expenses:Food  ; type: E
 
 # Full-line comment
 

--- a/src/__tests__/parse_ledger_to_raw.test.ts
+++ b/src/__tests__/parse_ledger_to_raw.test.ts
@@ -17,7 +17,7 @@ test.before((t) => {
     Assets:Investments     20 funds @ $1.00
 
 account Assets:Chequing
-account Expenses:Food ; type: E
+account Expenses:Food  ; type: E
 
 # Full-line comment
 

--- a/src/__tests__/parser/journal_item.test.ts
+++ b/src/__tests__/parser/journal_item.test.ts
@@ -2,6 +2,7 @@ import anyTest, { TestInterface } from 'ava';
 
 import {
   AccountDirective,
+  AccountName,
   CommentText,
   CommodityDirective,
   CommodityText,
@@ -13,7 +14,6 @@ import {
   NEWLINE,
   PDirective,
   PDirectiveCommodityText,
-  RealAccountName,
   SemicolonComment
 } from '../../lib/lexer/tokens';
 import HLedgerParser from '../../lib/parser';
@@ -112,7 +112,7 @@ test('parses a price directive', (t) => {
 test('parses an account directive', (t) => {
   t.context.lexer
     .addToken(AccountDirective, 'account')
-    .addToken(RealAccountName, 'Assets:Chequing')
+    .addToken(AccountName, 'Assets:Chequing')
     .addToken(NEWLINE, '\n');
   HLedgerParser.input = t.context.lexer.tokenize();
 
@@ -122,7 +122,7 @@ test('parses an account directive', (t) => {
       accountDirective: [
         {
           AccountDirective: 1,
-          RealAccountName: 1,
+          AccountName: 1,
           NEWLINE: 1
         }
       ]

--- a/src/__tests__/raw_to_cooked_ledger.test.ts
+++ b/src/__tests__/raw_to_cooked_ledger.test.ts
@@ -15,7 +15,7 @@ test('converts from raw journal to cooked journal', (t) => {
     Assets:Investments     20 funds @ $1.00
 
 account Assets:Chequing
-account Expenses:Food ; type: E
+account Expenses:Food  ; type: E
 
 # Full-line comment
 

--- a/src/__tests__/raw_to_cooked_visitor/account_directive.test.ts
+++ b/src/__tests__/raw_to_cooked_visitor/account_directive.test.ts
@@ -20,7 +20,7 @@ test('parses an account directive', (t) => {
 
 test('parses an account directive with an inline comment containing a tag and value', (t) => {
   const result = RawToCookedVisitor.journal(
-    parseLedgerToRaw(`account Assets:Chequing ;type: A\n`).rawJournal
+    parseLedgerToRaw(`account Assets:Chequing  ;type: A\n`).rawJournal
   );
   t.is(result.accounts.length, 1, 'should have 1 parsed account directive');
   t.deepEqual(
@@ -50,7 +50,7 @@ test('parses an account directive with a subdirective tag and value', (t) => {
 
 test('parses an account directive with combined inline and subdirective tags', (t) => {
   const result = RawToCookedVisitor.journal(
-    parseLedgerToRaw(`account Assets:Chequing ;secret:\n    ;type: A\n`)
+    parseLedgerToRaw(`account Assets:Chequing  ;secret:\n    ;type: A\n`)
       .rawJournal
   );
   t.is(result.accounts.length, 1, 'should have 1 parsed account directive');

--- a/src/lib/hledger_cst.ts
+++ b/src/lib/hledger_cst.ts
@@ -99,7 +99,8 @@ export interface AccountDirectiveCstNode extends CstNode {
 
 export type AccountDirectiveCstChildren = {
   AccountDirective: IToken[];
-  RealAccountName: IToken[];
+  AccountName: IToken[];
+  DOUBLE_WS?: IToken[];
   inlineComment?: InlineCommentCstNode[];
   NEWLINE: IToken[];
   accountDirectiveContentLine?: AccountDirectiveContentLineCstNode[];

--- a/src/lib/lexer/modes.ts
+++ b/src/lib/lexer/modes.ts
@@ -1,5 +1,6 @@
 import {
   AccountDirective,
+  AccountName,
   AMOUNT_WS,
   ASTERISK,
   ASTERISK_AT_START,
@@ -10,6 +11,7 @@ import {
   DASH,
   DateAtStart,
   DefaultCommodityDirective,
+  DOUBLE_WS,
   EQUALS,
   FormatSubdirective,
   HASHTAG_AT_START,
@@ -67,9 +69,10 @@ export const indent_mode = [
 
 export const account_mode = [
   NEWLINE,
+  DOUBLE_WS,
   SINGLE_WS,
   SemicolonComment,
-  RealAccountName
+  AccountName
 ];
 
 export const comment_mode = [

--- a/src/lib/lexer/tokens.ts
+++ b/src/lib/lexer/tokens.ts
@@ -35,6 +35,11 @@ export const SINGLE_WS = createToken({
   group: Lexer.SKIPPED
 });
 
+export const DOUBLE_WS = createToken({
+  name: 'DOUBLE_WS',
+  pattern: /[ \t]{2}/,
+});
+
 export const DIGIT = createToken({ name: 'DIGIT', pattern: /\d/ });
 export const SLASH = createToken({ name: 'SLASH', pattern: '/' });
 export const DOT = createToken({ name: 'DOT', pattern: '.' });
@@ -138,6 +143,12 @@ export const AccountDirective = createToken({
   start_chars_hint: ['A', 'a'],
   line_breaks: false,
   push_mode: 'account_mode'
+});
+
+export const AccountName = createToken({
+  name: 'AccountName',
+  pattern: matchAccountName(),
+  line_breaks: false
 });
 
 // ====- Posting Tokens -====

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -3,6 +3,7 @@ import { CstParser } from 'chevrotain';
 import { tokenModeDefinitions } from './lexer';
 import {
   AccountDirective,
+  AccountName,
   AMOUNT_WS,
   ASTERISK,
   ASTERISK_AT_START,
@@ -13,6 +14,7 @@ import {
   DASH,
   DateAtStart,
   DefaultCommodityDirective,
+  DOUBLE_WS,
   EQUALS,
   FormatSubdirective,
   HASHTAG_AT_START,
@@ -115,8 +117,9 @@ class HLedgerParser extends CstParser {
 
   public accountDirective = this.RULE('accountDirective', () => {
     this.CONSUME(AccountDirective);
-    this.CONSUME(RealAccountName);
+    this.CONSUME(AccountName);
     this.OPTION(() => {
+      this.CONSUME(DOUBLE_WS);
       this.SUBRULE(this.inlineComment);
     });
     this.CONSUME(NEWLINE);

--- a/src/lib/visitors/cst_to_raw.ts
+++ b/src/lib/visitors/cst_to_raw.ts
@@ -128,7 +128,7 @@ class HledgerToRawVisitor extends BaseCstVisitor {
       ?.filter(notEmpty);
 
     return {
-      account: ctx.RealAccountName[0].payload as string[],
+      account: ctx.AccountName[0].payload as string[],
       comments: ctx.inlineComment
         ? this.inlineComment(ctx.inlineComment[0].children)
         : undefined,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - bug fix

- **What is the current behavior?** (You can also link to an open issue here)
  - Single spaces between account directives and inline comments are allowed

- **What is the new behavior (if this is a feature change)?**
  - A double space is now required after account directives if an inline comment is appended

- **Other information**:

fix #14